### PR TITLE
add docker support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM openjdk:8-jre
+
+ADD ccu-historian-bin.zip /tmp/
+
+RUN apt-get update
+RUN apt-get install unzip
+
+RUN mkdir /opt/ccu-historian
+RUN mkdir /opt/ccu-historian/data
+RUN mkdir /opt/ccu-historian/backup
+
+RUN unzip /tmp/ccu-historian-bin.zip -d /opt/ccu-historian
+
+EXPOSE 80 2098 2099 8082 9092 5435
+
+WORKDIR /opt/ccu-historian
+
+CMD ["java", "-jar", "ccu-historian.jar"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.6'
+services:
+  ccu-historian:
+    # Build your image before running this compose file. 
+    # Execute this in the same directory as your Dockerfile and the ccu-historian-bin.zip is saved:
+    # $ docker build --tag=ccu-historian .
+    image: ccu-historian
+    ports:
+      - 10080:80            # change if neccessary           
+      - 2098:2098
+      - 2099:2099
+      - 8082:8082
+      - 9092:9092
+      - 5432:5435
+    volumes:
+      # save the database, backups and the configuration file outside of the container
+      # use simple slashes ( / ) for windows file pathes, as you do in unix file systems - example: c:/Users/myUser/Documents/docker/ccu-historian/database
+      - type: bind
+        source: < /path/to/database/folder >                                # change this
+        target: /opt/ccu-historian/data 
+      - type: bind
+        source: < /path/to/backup/folder >                                  # change this
+        target: /opt/ccu-historian/backup
+      - type: bind
+        source: < /path/to/configuration/folder/ccu-historian.config >      # change this
+        target: /opt/ccu-historian/ccu-historian.config
+    restart: unless-stopped


### PR DESCRIPTION
Hallo, 

ich finde den ccu-historian ein super Projekt! Da ich ihn bei mir in einem Dockercontainer laufen lasse, habe ich hierzu ein Dockerfile und eine docker-compose.yml vorbereitet.
Vielleicht wollt ihr diese ja zu eurem Repository hinzufügen, damit andere diese verwenden können.

Um einen lauffähigen Container zu erzeugen, muss man lediglich 4 Schritte befolgen: 

1. Verzeichnisse für Datanbank und Backup erstellen 
Es muss auf dem Hostsystem jeweils ein Ordner für die Datenbank und die Backups erstellt werden

2. Konfigurationsdatei anpassen
Die Konfigurationsdatei muss auf dem Hostsystem abgespeichert werden und dort konfiguriert werden.

3. Docker Image bauen (Docker muss natürlich auf dem Host installiert sein)
Ein Ordner auf dem Host sollte folgende Dateien beinhalten: 
- Dockerfile 
- docker-compose.yml
- ccu-historian-bin.zip (das aktuelle Release der Windows/Unix/Mac Version)
Mit dem Terminal in diesen Ordner navigieren und folgenden Befehl ausführen: 
`docker build --tag=ccu-historian .`

4. Den Container Konfigurieren und starten
Dazu muss die docker-compose.yml angepasst werden. 
- Ports zwischen Hostsystem und dem Container mappen
- Den Pfad zum Datenbank Ordner (aus 1.) eintragen
- Den Pfad zum Backup Ordner (aus 1.) eintragen
- Den Pfad zur Konfigurationsdatei ccu-historian.config eintragen
Mit dem Terminal in diesem Ordner folgenden Befehl ausführen:
`docker-compose up`


Wer sich per ssh auf seine QNAP NAS einwählen kann, und dort das Image baut, kann den ccu-historian auf diese Weise auch in der ContainerStation laufen lassen.  

Viele Grüße
Hoytron