### PR TITLE
Swinging Door Algorithmus geändert

### DIFF
--- a/ccu-historian/src/mdz/ccuhistorian/eventprocessing/Preprocessor.groovy
+++ b/ccu-historian/src/mdz/ccuhistorian/eventprocessing/Preprocessor.groovy
@@ -69,7 +69,7 @@ public class Preprocessor extends BasicProducer<Event> implements Processor<Even
 					case Type.AVG_COMPR:
 					case Type.MIN_COMPR:
 					case Type.MAX_COMPR: applyIntervalProcessor(event, type, param); break
-					case Type.SWD_COMPR: applySwingingDoor(event, type, param/2.0); break
+					case Type.SWD_COMPR: applySwingingDoor(event, type, param); break
 				}
 			} else {
 				// forward unmodified


### PR DESCRIPTION
Implementiert den Swinging Door Algorithmus so, wie er z.B. [hier](https://github.com/emrumo/swingingdoor/blob/main/README.md) beschrieben oder in diesem [Video](https://www.youtube.com/watch?v=89hg2mme7S0) ab ca. 4:30 erklärt wird.


Die wesentlichen Unterschiede zur derzeitigen Version sind:

- Das "Scharnier" der Swinging Door liegt  im Startpunkt statt wie bisher im letzten Datenpunkt.

- Zur Entscheidung, ob ein Datenpunkt geschrieben werden muss, wird geprüft, ob die _direkte_ Verbindung zwischen Startpunkt und dem neuesten Datenpunkt (beide ohne Beaufschlagung mit der erlaubten Abweichung) innerhalb des durch die _vorherigen_ Datenpunkte aufgespannten Bereichs der Swinging Door liegt.  Die jetzige Version betrachtest nur die obere und untere Schranke der Swinging Door und schreibst, wenn diese sich überkreuzen.